### PR TITLE
Revert extra changes, and rename INT_MARK_DECL to full name.

### DIFF
--- a/include/interactive_markers/exports.h
+++ b/include/interactive_markers/exports.h
@@ -7,12 +7,12 @@
 
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
   #ifdef interactive_markers_EXPORTS // we are building a shared lib/dll
-    #define INT_MARK_DECL ROS_HELPER_EXPORT
+    #define INTERACTIVE_MARKERS_DECL ROS_HELPER_EXPORT
   #else // we are using shared lib/dll
-    #define INT_MARK_DECL ROS_HELPER_IMPORT
+    #define INTERACTIVE_MARKERS_DECL ROS_HELPER_IMPORT
   #endif
 #else // ros is being built around static libraries
-  #define INT_MARK_DECL
+  #define INTERACTIVE_MARKERS_DECL
 #endif
 
 #endif // INT_MARK_EXPORTDECL_H

--- a/include/interactive_markers/interactive_marker_client.h
+++ b/include/interactive_markers/interactive_marker_client.h
@@ -66,14 +66,14 @@ class SingleClient;
 /// All timestamped messages are being transformed into the target frame,
 /// while for non-timestamped messages it is ensured that the necessary
 /// tf transformation will be available.
-class INT_MARK_DECL InteractiveMarkerClient : boost::noncopyable
+class INTERACTIVE_MARKERS_DECL InteractiveMarkerClient : boost::noncopyable
 {
 public:
 
   enum StatusT {
-    STOK = 0,
-    STWARN = 1,
-    STERROR = 2
+    OK = 0,
+    WARN = 1,
+    ERROR = 2
   };
 
   typedef visualization_msgs::InteractiveMarkerUpdateConstPtr UpdateConstPtr;

--- a/include/interactive_markers/interactive_marker_server.h
+++ b/include/interactive_markers/interactive_marker_server.h
@@ -55,7 +55,7 @@ namespace interactive_markers
 ///
 /// Note: Keep in mind that changes made by calling insert(), erase(), setCallback() etc.
 ///       are not applied until calling applyChanges().
-class INT_MARK_DECL InteractiveMarkerServer : boost::noncopyable
+class INTERACTIVE_MARKERS_DECL InteractiveMarkerServer : boost::noncopyable
 {
 public:
 

--- a/include/interactive_markers/menu_handler.h
+++ b/include/interactive_markers/menu_handler.h
@@ -45,7 +45,7 @@ namespace interactive_markers
 
 // Simple non-intrusive helper class which creates a menu and maps its
 // entries to function callbacks
-class INT_MARK_DECL MenuHandler
+class INTERACTIVE_MARKERS_DECL MenuHandler
 {
 public:
 

--- a/include/interactive_markers/tools.h
+++ b/include/interactive_markers/tools.h
@@ -41,24 +41,24 @@ namespace interactive_markers
  *
  * This also calls uniqueifyControlNames().
  * @param msg      interactive marker to be completed */
-INT_MARK_DECL void autoComplete( visualization_msgs::InteractiveMarker &msg, bool enable_autocomplete_transparency = true );
+INTERACTIVE_MARKERS_DECL void autoComplete( visualization_msgs::InteractiveMarker &msg, bool enable_autocomplete_transparency = true );
 
 /// @brief fill in default values & insert default controls when none are specified
 /// @param msg      interactive marker which contains the control
 /// @param control  the control to be completed
-INT_MARK_DECL void autoComplete( const visualization_msgs::InteractiveMarker &msg,
+INTERACTIVE_MARKERS_DECL void autoComplete( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, bool enable_autocomplete_transparency = true );
 
 /** @brief Make sure all the control names are unique within the given msg.
  *
  * Appends _u0 _u1 etc to repeated names (not including the first of each).
  * This is called by autoComplete( visualization_msgs::InteractiveMarker &msg ). */
-INT_MARK_DECL void uniqueifyControlNames( visualization_msgs::InteractiveMarker& msg );
+INTERACTIVE_MARKERS_DECL void uniqueifyControlNames( visualization_msgs::InteractiveMarker& msg );
 
 /// make a quaternion with a fixed local x axis.
 /// The rotation around that axis will be chosen automatically.
 /// @param x,y,z    the designated x axis
-INT_MARK_DECL geometry_msgs::Quaternion makeQuaternion( float x, float y, float z );
+INTERACTIVE_MARKERS_DECL geometry_msgs::Quaternion makeQuaternion( float x, float y, float z );
 
 
 /// --- marker helpers ---
@@ -67,26 +67,26 @@ INT_MARK_DECL geometry_msgs::Quaternion makeQuaternion( float x, float y, float 
 /// @param msg      the interactive marker that this will go into
 /// @param control  the control where to insert the arrow marker
 /// @param pos      how far from the center should the arrow be, and on which side
-INT_MARK_DECL void makeArrow( const visualization_msgs::InteractiveMarker &msg,
+INTERACTIVE_MARKERS_DECL void makeArrow( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, float pos );
 
 /// @brief make a default-style disc marker (e.g for rotating) based on the properties of the given interactive marker
 /// @param msg      the interactive marker that this will go into
 /// @param width    width of the disc, relative to its inner radius
-INT_MARK_DECL void makeDisc( const visualization_msgs::InteractiveMarker &msg,
+INTERACTIVE_MARKERS_DECL void makeDisc( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, float width = 0.3 );
 
 /// @brief make a box which shows the given text and is view facing
 /// @param msg      the interactive marker that this will go into
 /// @param text     the text to display
-INT_MARK_DECL void makeViewFacingButton( const visualization_msgs::InteractiveMarker &msg,
+INTERACTIVE_MARKERS_DECL void makeViewFacingButton( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, std::string text );
 
 /// assign an RGB value to the given marker based on the given orientation
-INT_MARK_DECL void assignDefaultColor(visualization_msgs::Marker &marker, const geometry_msgs::Quaternion &quat );
+INTERACTIVE_MARKERS_DECL void assignDefaultColor(visualization_msgs::Marker &marker, const geometry_msgs::Quaternion &quat );
 
 /// create a control which shows the description of the interactive marker
-INT_MARK_DECL visualization_msgs::InteractiveMarkerControl makeTitle( const visualization_msgs::InteractiveMarker &msg );
+INTERACTIVE_MARKERS_DECL visualization_msgs::InteractiveMarkerControl makeTitle( const visualization_msgs::InteractiveMarker &msg );
 
 }
 

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -141,11 +141,11 @@ void InteractiveMarkerClient::subscribeUpdate()
     }
     catch( ros::Exception& e )
     {
-      callbacks_.statusCb( InteractiveMarkerClient::STERROR, "General", "Error subscribing: " + std::string(e.what()) );
+      callbacks_.statusCb( ERROR, "General", "Error subscribing: " + std::string(e.what()) );
       return;
     }
   }
-  callbacks_.statusCb( InteractiveMarkerClient::STOK, "General", "Waiting for messages.");
+  callbacks_.statusCb( OK, "General", "Waiting for messages.");
 }
 
 void InteractiveMarkerClient::subscribeInit()
@@ -160,7 +160,7 @@ void InteractiveMarkerClient::subscribeInit()
     }
     catch( ros::Exception& e )
     {
-      callbacks_.statusCb( InteractiveMarkerClient::STERROR, "General", "Error subscribing: " + std::string(e.what()) );
+      callbacks_.statusCb( ERROR, "General", "Error subscribing: " + std::string(e.what()) );
     }
   }
 }
@@ -168,12 +168,12 @@ void InteractiveMarkerClient::subscribeInit()
 template<class MsgConstPtrT>
 void InteractiveMarkerClient::process( const MsgConstPtrT& msg )
 {
-  callbacks_.statusCb( InteractiveMarkerClient::STOK, "General", "Receiving messages.");
+  callbacks_.statusCb( OK, "General", "Receiving messages.");
 
   // get caller ID of the sending entity
   if ( msg->server_id.empty() )
   {
-    callbacks_.statusCb( InteractiveMarkerClient::STERROR, "General", "Received message with empty server_id!");
+    callbacks_.statusCb( ERROR, "General", "Received message with empty server_id!");
     return;
   }
 
@@ -228,7 +228,7 @@ void InteractiveMarkerClient::update()
     // check if one publisher has gone offline
     if ( update_sub_.getNumPublishers() < last_num_publishers_ )
     {
-      callbacks_.statusCb( InteractiveMarkerClient::STERROR, "General", "Server is offline. Resetting." );
+      callbacks_.statusCb( ERROR, "General", "Server is offline. Resetting." );
       shutdown();
       subscribeUpdate();
       subscribeInit();
@@ -274,13 +274,13 @@ void InteractiveMarkerClient::statusCb( StatusT status, const std::string& serve
 {
   switch ( status )
   {
-  case InteractiveMarkerClient::STOK:
+  case OK:
     DBG_MSG( "%s: %s (Status: OK)", server_id.c_str(), msg.c_str() );
     break;
-  case InteractiveMarkerClient::STWARN:
+  case WARN:
     DBG_MSG( "%s: %s (Status: WARNING)", server_id.c_str(), msg.c_str() );
     break;
-  case InteractiveMarkerClient::STERROR:
+  case ERROR:
     DBG_MSG( "%s: %s (Status: ERROR)", server_id.c_str(), msg.c_str() );
     break;
   }

--- a/src/single_client.cpp
+++ b/src/single_client.cpp
@@ -55,7 +55,7 @@ SingleClient::SingleClient(
 , server_id_(server_id)
 , warn_keepalive_(false)
 {
-  callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "Waiting for init message." );
+  callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "Waiting for init message." );
 }
 
 SingleClient::~SingleClient()
@@ -76,7 +76,7 @@ void SingleClient::process(const visualization_msgs::InteractiveMarkerInit::Cons
       init_queue_.pop_back();
     }
     init_queue_.push_front( InitMessageContext(tf_, target_frame_, msg, enable_autocomplete_transparency ) );
-    callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "Init message received." );
+    callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "Init message received." );
     break;
 
   case RECEIVING:
@@ -163,7 +163,7 @@ void SingleClient::update()
   case TF_ERROR:
     if ( state_.getDuration().toSec() > 1.0 )
     {
-      callbacks_.statusCb( InteractiveMarkerClient::STERROR, server_id_, "1 second has passed. Re-initializing." );
+      callbacks_.statusCb( InteractiveMarkerClient::ERROR, server_id_, "1 second has passed. Re-initializing." );
       state_ = INIT;
     }
     break;
@@ -177,13 +177,13 @@ void SingleClient::checkKeepAlive()
   {
     std::ostringstream s;
     s << "No update received for " << round(time_since_upd) << " seconds.";
-    callbacks_.statusCb( InteractiveMarkerClient::STWARN, server_id_, s.str() );
+    callbacks_.statusCb( InteractiveMarkerClient::WARN, server_id_, s.str() );
     warn_keepalive_ = true;
   }
   else if ( warn_keepalive_ )
   {
     warn_keepalive_ = false;
-    callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "OK" );
+    callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "OK" );
   }
 }
 
@@ -196,7 +196,7 @@ void SingleClient::checkInitFinished()
 
   if (last_update_seq_num_ == (uint64_t)-1)
   {
-    callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "Initialization: Waiting for first update/keep-alive message." );
+    callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "Initialization: Waiting for first update/keep-alive message." );
     return;
   }
 
@@ -208,7 +208,7 @@ void SingleClient::checkInitFinished()
 
     if ( !init_it->isReady() )
     {
-      callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "Initialization: Waiting for tf info." );
+      callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "Initialization: Waiting for tf info." );
     }
     else if ( next_up_exists )
     {
@@ -220,7 +220,7 @@ void SingleClient::checkInitFinished()
       }
 
       callbacks_.initCb( init_it->msg );
-      callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "Receiving updates." );
+      callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "Receiving updates." );
 
       init_queue_.clear();
       state_ = RECEIVING;
@@ -246,7 +246,7 @@ void SingleClient::transformInitMsgs()
       // in case it is the only one we will receive.
       std::ostringstream s;
       s << "Cannot get tf info for init message with sequence number " << it->msg->seq_num << ". Error: " << e.what();
-      callbacks_.statusCb( InteractiveMarkerClient::STWARN, server_id_, s.str() );
+      callbacks_.statusCb( InteractiveMarkerClient::WARN, server_id_, s.str() );
     }
     ++it;
   }
@@ -287,7 +287,7 @@ void SingleClient::errorReset( std::string error_msg )
   last_update_seq_num_ = -1;
   warn_keepalive_ = false;
 
-  callbacks_.statusCb( InteractiveMarkerClient::STERROR, server_id_, error_msg );
+  callbacks_.statusCb( InteractiveMarkerClient::ERROR, server_id_, error_msg );
   callbacks_.resetCb( server_id_ );
 }
 
@@ -295,7 +295,7 @@ void SingleClient::pushUpdates()
 {
   if( !update_queue_.empty() && update_queue_.back().isReady() )
   {
-    callbacks_.statusCb( InteractiveMarkerClient::STOK, server_id_, "OK" );
+    callbacks_.statusCb( InteractiveMarkerClient::OK, server_id_, "OK" );
   }
   while( !update_queue_.empty() && update_queue_.back().isReady() )
   {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -32,7 +32,6 @@
 #include <tf/LinearMath/Quaternion.h>
 #include <tf/LinearMath/Matrix3x3.h>
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <assert.h>
 


### PR DESCRIPTION
* Revert the StatusT  value renames.
* Rename INT_MARK_DECL  to INTERACTIVE_MARKERS_DECL to be more aligned with ROS naming style.